### PR TITLE
feat: Implement chat history feature

### DIFF
--- a/app/api/chat/history/route.js
+++ b/app/api/chat/history/route.js
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import ChatMessage from '../../../../../chatMessage'; // Assuming chatMessage.js is at the project root
+import mongoose from 'mongoose';
+
+// Placeholder for MongoDB connection utility
+// In a real app, this would be in a separate file e.g., lib/mongodb.js
+async function connectToDatabase() {
+  if (mongoose.connections[0].readyState) {
+    // Use current db connection
+    return;
+  }
+  // Use new db connection
+  // Ensure MONGO_URI is set in your environment variables
+  if (!process.env.MONGO_URI) {
+    throw new Error('Please define the MONGO_URI environment variable inside .env.local');
+  }
+  await mongoose.connect(process.env.MONGO_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+}
+// Mock MONGO_URI for now if not set, for the sake of tool execution without .env
+// In a real scenario, this should be handled by the environment.
+if (!process.env.MONGO_URI) {
+    process.env.MONGO_URI = "mongodb://localhost:27017/chat_app_db_test";
+}
+
+export async function GET(request) {
+  try {
+    await connectToDatabase();
+
+    const { searchParams } = new URL(request.url);
+    const sessionId = searchParams.get('sessionId');
+    const userId = searchParams.get('userId'); // Optional
+
+    if (!sessionId) {
+      return NextResponse.json({ error: 'Missing required query parameter: sessionId' }, { status: 400 });
+    }
+
+    const query = { sessionId };
+    if (userId) {
+      query.userId = userId;
+    }
+
+    const messages = await ChatMessage.find(query).sort({ timestamp: 'asc' }).exec();
+
+    return NextResponse.json(messages, { status: 200 });
+
+  } catch (error) {
+    console.error('Error in GET /api/chat/history:', error);
+    if (error.message.includes('MONGO_URI')) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    // Generic server error
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -1,0 +1,127 @@
+import { NextResponse } from 'next/server';
+import ChatMessage from '../../../../chatMessage'; // Assuming chatMessage.js is at the project root
+import mongoose from 'mongoose';
+
+// Placeholder for MongoDB connection utility
+// In a real app, this would be in a separate file e.g., lib/mongodb.js
+async function connectToDatabase() {
+  if (mongoose.connections[0].readyState) {
+    // Use current db connection
+    return;
+  }
+  // Use new db connection
+  // Ensure MONGO_URI is set in your environment variables
+  if (!process.env.MONGO_URI) {
+    throw new Error('Please define the MONGO_URI environment variable inside .env.local');
+  }
+  await mongoose.connect(process.env.MONGO_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+}
+// Mock MONGO_URI for now if not set, for the sake of tool execution without .env
+// In a real scenario, this should be handled by the environment.
+if (!process.env.MONGO_URI) {
+    process.env.MONGO_URI = "mongodb://localhost:27017/chat_app_db_test";
+}
+
+/**
+ * Placeholder function for AI interaction that includes chat history.
+ * Logs the received data and returns a simulated response.
+ */
+async function getAIResponseWithHistory(currentUserMessageText, formattedHistory) {
+  console.log("Current user message:", currentUserMessageText);
+  console.log("Formatted history for AI:", JSON.stringify(formattedHistory, null, 2));
+
+  // TODO: Replace this with your actual AI API call.
+  // Example using OpenAI's SDK (ensure you have it installed and configured):
+  //
+  // import OpenAI from 'openai';
+  // const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  //
+  // const messagesForAI = [
+  //   ...formattedHistory,
+  //   { role: 'user', content: currentUserMessageText }
+  // ];
+  //
+  // try {
+  //   const completion = await openai.chat.completions.create({
+  //     messages: messagesForAI,
+  //     model: 'gpt-3.5-turbo', // Or your preferred model
+  //   });
+  //   if (completion.choices && completion.choices.length > 0 && completion.choices[0].message) {
+  //     return completion.choices[0].message.content;
+  //   } else {
+  //     console.error("AI response format unexpected:", completion);
+  //     return "AI Error: Could not process response.";
+  //   }
+  // } catch (error) {
+  //   console.error("Error calling AI API:", error);
+  //   return "AI Error: Exception during API call.";
+  // }
+
+  // For now, return a simulated response:
+  return `AI (with history): Processed '${currentUserMessageText}'. History items: ${formattedHistory.length}`;
+}
+
+export async function POST(request) {
+  try {
+    await connectToDatabase();
+
+    const body = await request.json();
+    const { message, sessionId, userId } = body;
+
+    if (!message || !sessionId) {
+      return NextResponse.json({ error: 'Missing required fields: message and sessionId' }, { status: 400 });
+    }
+
+    // Save User Message
+    const userMessage = new ChatMessage({
+      sessionId,
+      userId: userId || null,
+      sender: 'user',
+      message,
+    });
+    await userMessage.save();
+
+    // Fetch Recent History
+    const historyLimit = 10; // Retrieve the last 10 messages
+    const recentMessages = await ChatMessage.find({ sessionId })
+      .sort({ timestamp: -1 }) // Get the most recent messages first
+      .limit(historyLimit)
+      .exec();
+
+    // Format History for AI (and reverse to chronological order for AI)
+    const formattedHistory = recentMessages
+      .map(msg => ({
+        role: msg.sender === 'user' ? 'user' : 'assistant', // Map 'sender' to 'role'
+        content: msg.message, // Map 'message' to 'content'
+      }))
+      .reverse(); // Reverse to maintain chronological order (oldest to newest)
+
+    // Call the AI with the current message and the formatted history
+    const aiResponseText = await getAIResponseWithHistory(message, formattedHistory);
+
+    // Save AI Response
+    const aiMessage = new ChatMessage({
+      sessionId,
+      userId: userId || null,
+      sender: 'ai',
+      message: aiResponseText,
+    });
+    await aiMessage.save();
+
+    return NextResponse.json({ aiResponse: aiResponseText }, { status: 200 });
+
+  } catch (error) {
+    console.error('Error in POST /api/chat:', error);
+    if (error.name === 'ValidationError') {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    if (error.message.includes('MONGO_URI')) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    // Generic server error
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/app/chat/page.js
+++ b/app/chat/page.js
@@ -1,0 +1,166 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+
+// Helper function to generate a simple unique ID for sessionId if not in localStorage
+const generateSessionId = () => {
+  return `session_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+};
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [sessionId, setSessionId] = useState(null);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(true);
+  const [error, setError] = useState(null);
+  const messagesEndRef = useRef(null);
+
+  // Effect for Session ID management
+  useEffect(() => {
+    let storedSessionId = localStorage.getItem('chatSessionId');
+    if (!storedSessionId) {
+      storedSessionId = generateSessionId();
+      localStorage.setItem('chatSessionId', storedSessionId);
+    }
+    setSessionId(storedSessionId);
+  }, []);
+
+  // Effect for fetching chat history when sessionId is available
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const fetchHistory = async () => {
+      setIsLoadingHistory(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/chat/history?sessionId=${sessionId}`);
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.error || `Failed to fetch history: ${response.status}`);
+        }
+        const history = await response.json();
+        // Ensure history messages are in the correct format
+        const formattedHistory = history.map(msg => ({
+            sender: msg.sender,
+            text: msg.message, // API returns 'message', client uses 'text'
+            timestamp: msg.timestamp
+        }));
+        setMessages(formattedHistory);
+      } catch (err) {
+        console.error("Error fetching chat history:", err);
+        setError(err.message);
+        // Optionally, clear messages or set to an error state
+        // setMessages([]); 
+      } finally {
+        setIsLoadingHistory(false);
+      }
+    };
+
+    fetchHistory();
+  }, [sessionId]);
+
+  // Scroll to bottom of messages
+  useEffect(() => {
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const newMessageText = inputValue.trim();
+    if (!newMessageText || !sessionId) return;
+
+    const userMessage = {
+      sender: 'user',
+      text: newMessageText,
+      timestamp: new Date().toISOString(),
+    };
+    setMessages((prevMessages) => [...prevMessages, userMessage]);
+    setInputValue('');
+
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          message: newMessageText,
+          sessionId: sessionId,
+          // userId: 'optionalUserId' // Include if you have user authentication
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `API Error: ${response.status}`);
+      }
+
+      const aiResponse = await response.json(); // Expects { aiResponse: "text" }
+      
+      const aiMessage = {
+        sender: 'ai',
+        text: aiResponse.aiResponse, // API returns { aiResponse: "..." }
+        timestamp: new Date().toISOString(),
+      };
+      setMessages((prevMessages) => [...prevMessages, aiMessage]);
+
+    } catch (err) {
+      console.error("Error sending message:", err);
+      setError(err.message);
+      // Optionally, add an error message to the chat or revert optimistic update
+      const errorMessage = {
+        sender: 'system', // Or 'ai' with an error flag
+        text: `Error: ${err.message}. Please try again.`,
+        timestamp: new Date().toISOString(),
+      };
+      setMessages((prevMessages) => [...prevMessages, errorMessage]);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '90vh', maxWidth: '700px', margin: '0 auto', border: '1px solid #ccc', borderRadius: '8px', overflow: 'hidden' }}>
+      <h1 style={{ textAlign: 'center', padding: '10px 0', borderBottom: '1px solid #eee', margin: 0 }}>Chat</h1>
+      <div style={{ flexGrow: 1, overflowY: 'auto', padding: '10px 20px' }}>
+        {isLoadingHistory && <p>Loading history...</p>}
+        {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+        {!isLoadingHistory && messages.length === 0 && !error && <p>No messages yet. Start chatting!</p>}
+        
+        {messages.map((msg, index) => (
+          <div key={index} style={{
+            margin: '10px 0',
+            padding: '8px 12px',
+            borderRadius: '7px',
+            alignSelf: msg.sender === 'user' ? 'flex-end' : 'flex-start',
+            backgroundColor: msg.sender === 'user' ? '#007bff' : (msg.sender === 'ai' ? '#e9ecef' : '#f8d7da'),
+            color: msg.sender === 'user' ? 'white' : 'black',
+            textAlign: msg.sender === 'user' ? 'right' : 'left',
+            marginLeft: msg.sender === 'user' ? 'auto' : '0',
+            marginRight: msg.sender === 'ai' ? 'auto' : '0',
+            maxWidth: '75%',
+          }}>
+            <strong>{msg.sender === 'user' ? 'You' : (msg.sender === 'ai' ? 'AI' : 'System')}: </strong>{msg.text}
+            <div style={{ fontSize: '0.75em', color: msg.sender === 'user' ? '#f0f0f0' : '#555', marginTop: '3px' }}>
+              {new Date(msg.timestamp).toLocaleTimeString()}
+            </div>
+          </div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', padding: '10px', borderTop: '1px solid #eee' }}>
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder="Type a message..."
+          style={{ flexGrow: 1, padding: '10px', borderRadius: '5px', border: '1px solid #ddd', marginRight: '10px' }}
+          aria-label="Chat message input"
+        />
+        <button type="submit" style={{ padding: '10px 15px', borderRadius: '5px', border: 'none', backgroundColor: '#007bff', color: 'white', cursor: 'pointer' }}>
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/chatMessage.js
+++ b/chatMessage.js
@@ -1,0 +1,32 @@
+const mongoose = require('mongoose');
+
+const chatMessageSchema = new mongoose.Schema({
+  sessionId: {
+    type: String,
+    required: true,
+    indexed: true,
+  },
+  userId: {
+    type: String,
+    required: false, // Can be null for anonymous chats
+    indexed: true,
+  },
+  sender: {
+    type: String,
+    required: true,
+    enum: ['user', 'ai'],
+  },
+  message: {
+    type: String,
+    required: true,
+  },
+  timestamp: {
+    type: Date,
+    required: true,
+    default: Date.now,
+  },
+});
+
+const ChatMessage = mongoose.model('ChatMessage', chatMessageSchema);
+
+module.exports = ChatMessage;


### PR DESCRIPTION
Adds functionality to save and retrieve chat conversations.

Key changes include:
- MongoDB schema (`ChatMessage`) for storing your and my messages with session tracking.
- Next.js API route (`/api/chat`) to handle incoming messages, save them, interact with me (with history context), and save my responses.
- Next.js API route (`/api/chat/history`) to retrieve chat history for a session.
- Frontend chat component updated to:
    - Manage a `sessionId` using localStorage.
    - Fetch and display existing chat history on load.
    - Send new messages to the backend and display responses.
    - Pass chat history to me for contextual responses (via backend).

My interaction in the backend API includes a placeholder that needs to be replaced with the specific AI model integration.